### PR TITLE
Fix common github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,9 +190,8 @@ jobs:
         run: |
           git remote -v
           git fetch --depth=1 origin master
-      - name: Only allow configs changes
-        run: |
-          find . -type f ! -name '*.yaml' ! -name '*.yml' ! -name '*.txt' ! -name '*.md' ! -name '*.conf' -exec git diff --exit-code origin/master -- {} +
+      - name: NSMBot should update only config files
+        run: find . -type f ! -name 'go.mod' ! -name 'go.sum' ! -name '*.yaml' ! -name '*.yml' ! -name '*.txt' ! -name '*.md' ! -name '*.conf' -exec git diff --exit-code origin/master -- {} +
       - name: Automerge nsmbot PR
         uses: ridedott/merge-me-action@master
         with:

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -14,7 +14,7 @@ jobs:
       TAG: master
       ORG: networkservicemeshci
       CGO_ENABLED: 0
-      NAME: ${{ github.repository }}
+      NAME: ${{ github.event.repository.name }}
     if: github.repository != 'networkservicemesh/cmd-template'
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -12,7 +12,7 @@ jobs:
         repository: [cmd-registry-proxy-dns, cmd-nsc]
     name: Update ${{ matrix.repository }}
     runs-on: ubuntu-latest
-    if: github.repository != 'networkservicemesh/cmd-template'
+    if: github.repository == 'networkservicemesh/cmd-template'
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2

--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -53,7 +53,7 @@ jobs:
           git config --global user.name "NSMBot"
           git remote add cmd_template https://github.com/networkservicemesh/cmd-template.git
           git fetch cmd_template
-          git cherry-pick --no-commit ${GITHUB_SHA} -m 1
+          git diff cmd_template/master -R | git apply
           git commit -s -F /tmp/commit-message
           git checkout -b update/${{ github.repository }}
           git push -f origin update/${{ github.repository }}


### PR DESCRIPTION
## Motivation

1. Fixed problem with docker push job (before it tried to push image with tag `networkservicemeshci/networkservicemesh/${repo-name}`)
2. Fixed condition for update-cmd-repositories.yaml 
3. **Patches for dependent repositories are applying based on the diff.**