### PR TITLE
fix: Update only config files for dependent repositories

### DIFF
--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -54,6 +54,12 @@ jobs:
           git remote add cmd_template https://github.com/networkservicemesh/cmd-template.git
           git fetch cmd_template
           git diff cmd_template/master -R | git apply
+          git add -- .*.yaml
+          git add -- .*.yml
+          git add -- .*.md
+          git add -- .*.conf
+          git add -- .*.txt
+          git reset -- $(cat exclude.patch.conf)
           git commit -s -F /tmp/commit-message
           git checkout -b update/${{ github.repository }}
           git push -f origin update/${{ github.repository }}

--- a/exclude.patch.conf
+++ b/exclude.patch.conf
@@ -1,0 +1,2 @@
+## Put here paths to files which should be ignored on updating from depended repository
+README.md


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Description

1. Dependent repositories should be able to exclude from update some configs (e.g. if dependent repositories have updated some files manually).
2. Update from cmd-template should include only config files.