### PR TITLE
fix: Remove test job from ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: shellcheck
         uses: fkautz/shell-linter@v1.0.1
-  build-and-test:
+  build:
     name: build and test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -39,8 +39,6 @@ jobs:
           go-version: 1.13.4
       - name: Build
         run: go build -race  ./...
-      - name: Test
-        run: go test -race ./...
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
@@ -186,7 +184,8 @@ jobs:
     name: automerge
     runs-on: ubuntu-latest
     needs:
-      - build-and-test
+      - build
+      - docker
     if: github.actor == 'nsmbot' && github.base_ref == 'master' && github.event_name == 'pull_request'
     steps:
       - name: Check out the code

--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -56,7 +56,9 @@ jobs:
           git diff cmd_template/master -R | git apply
           git add $(git ls-tree --name-only -r cmd_template/master | grep ".*\.yml\|.*\.yaml\|.*\.md\|.*\.txt\|.*.\.conf")
           git restore --staged -- $(cat exclude.patch.conf)
+          git restore -- $(cat exclude.patch.conf)
           git restore --staged -- exclude.patch.conf
+          git restore -- exclude.patch.conf
           if ! [ -n "$(git diff --cached --exit-code)" ]; then
             exit 0;
           fi


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

All cmd-apps covers by docker tests. We actually do not need to test apps under a shell to prevent spire test issues.