### PR TITLE
fix: Created .templateignore file should be empty for new repositories

### DIFF
--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -59,6 +59,8 @@ jobs:
             git restore --staged -- .templateignore &&
             git restore -- .templateignore
           } || {
+            rm .templateignore
+            touch .templateignore
             git add .templateignore
           }
           git restore --staged -- $(cat .templateignore)


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

Fixes https://github.com/networkservicemesh/cmd-template/runs/1321875253