### PR TITLE
fix: set-env is deprecated

### DIFF
--- a/.github/workflows/pr-for-updates.yaml
+++ b/.github/workflows/pr-for-updates.yaml
@@ -14,7 +14,7 @@ jobs:
         run: |
           PULL_REQUEST_BODY=$(git log -1)
           echo ${PULL_REQUEST_BODY}
-          echo "::set-env name=PULL_REQUEST_BODY::${PULL_REQUEST_BODY}"
+          echo PULL_REQUEST_BODY=${PULL_REQUEST_BODY} >> $GITHUB_ENV
       - name: pull-request-action
         uses: vsoch/pull-request-action@1.0.6
         env:


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

Dependent repos can not get a patch because of
```
Error: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This PR fixes the problem.