### PR TITLE
fix: Error "too many arguments"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,7 +266,7 @@ jobs:
           git config --global user.name "NSMBot"
           git commit -s -F /tmp/commit-message
           git checkout -b update/"${branchName}"
-          while [ git push origin update/"${branchName}" ]; do
+          while [ $(git push origin update/"${branchName}") ]; do
             git fetch origin update/"${branchName}"
             git rebase origin/update/"${branchName}"
           done

--- a/.github/workflows/update-integration-k8s-kind.yaml
+++ b/.github/workflows/update-integration-k8s-kind.yaml
@@ -63,7 +63,7 @@ jobs:
           git config --global user.name "NSMBot"
           git commit -s -F /tmp/commit-message
           git checkout -b update/"${branchName}"
-          while [ git push -f origin update/"${branchName}" ]; do
+          while [ $(git push origin update/"${branchName}") ]; do
             git fetch origin update/"${branchName}"
             git rebase origin/update/"${branchName}"
           done


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

With last fixes cmd apps able to create a commit for the integration repo but still not able to push changes due to the error "too many arguments"

```
Switched to a new branch 'update/cmd-registry-memory'
[master 333f9d9] Update application version to latest version from networkservicemesh/cmd-registry-memory@master networkservicemesh/cmd-registry-memory#136
/home/runner/work/_temp/b566ef23-cc83-4f84-9d76-d724c881e2b7.sh: line 18: [: too many arguments
 1 file changed, 1 insertion(+), 1 deletion(-)
```