### PR TITLE
fix: move working directory to sync-files

### DIFF
--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -35,12 +35,12 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - name: Sync config files
         if: matrix.repository != 'networkservicemesh/cmd-template'
-        uses: denis-tingajkin/sync-files@v1
-        working-directory: ${{ matrix.repository}}
+        uses: denis-tingajkin/sync-files@v1.0.1
         with:
           git-author-email: 'nsmbot@networkservicmesh.io'
           git-author-name: 'NSMBot'
           src-branch-name: master
+          directory: ${{ matrix.repository}}
           src-repository: ${{ github.repository }}
           allow-files-pattern: (.*\.yaml|.*\.yml|.*\.txt|.*\.md|.*\.conf)
           exclude-files: |


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

this PR fixes: `The workflow is not valid. .github/workflows/update-cmd-repositories.yaml (Line: 39, Col: 9): Unexpected value 'working-directory'`