### PR TITLE
Disable sloppyReassign linter check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,7 +112,7 @@ linters-settings:
       - regexpPattern
       - singleCaseSwitch
       - sloppyLen
-      - sloppyReassign
+      # - sloppyReassign
       - stringXbytes
       - switchTrue
       - typeAssertChain


### PR DESCRIPTION
`sloppyReassign` check is always conflicting with `shadow` check.