### PR TITLE
Update CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Restrict dependencies on github.com/networkservicemesh/*
         env:
-          ALLOWED_REPOSITORIES: "sdk, api, sdk-k8s, sdk-vppagent, sdk-sriov"
+          ALLOWED_REPOSITORIES: "sdk, api, sdk-k8s, sdk-vpp, sdk-sriov"
         run: |
           for i in $(grep github.com/networkservicemesh/ go.mod | grep -v '^module' | sed 's;.*\(github.com\/networkservicemesh\/[^ ]*\).*;\1;g');do
             if ! [ "$(echo ${ALLOWED_REPOSITORIES} | grep ${i#github.com/networkservicemesh/})" ]; then
@@ -85,7 +85,7 @@ jobs:
           done
 
   checkgomod:
-    name: check go.mod and go.sum
+    name: Check go.mod and go.sum
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -93,32 +93,31 @@ jobs:
         with:
           go-version: 1.15
       - run: go mod tidy
-      - name: Check for changes in go.mod or go.sum
+      - name: Check for changes
         run: |
-          git diff --name-only --exit-code go.mod || ( echo "Run go tidy" && false )
-          git diff --name-only --exit-code go.sum || ( echo "Run go tidy" && false )
+          git diff --name-only --exit-code || ( echo "Run go mod tidy" && false )
 
   gogenerate:
     name: Check generated files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@master
         with:
           version: '3.8.0'
       - uses: actions/setup-go@v1
         with:
           go-version: 1.15
-      - name: Install proto-gen-go
-        run: go get -u github.com/golang/protobuf/protoc-gen-go@v1.3.3
-      - name: Install proto-gen-go
-        run: go get github.com/searKing/golang/tools/cmd/go-syncmap
-      - name: Generate files
-        run: go generate ./...
-      - name: Check for changes in generated code
+      - name: Instal go generate tools
         run: |
-          git diff -- '*.pb.go' || ( echo "Rerun go generate ./... locally and resubmit" && false )
-          git diff -- '*.gen.go' || ( echo "Rerun go generate ./... locally and resubmit" && false )
+          go get -u github.com/golang/protobuf/protoc-gen-go@v1.3.3
+          go get github.com/searKing/golang/tools/cmd/go-syncmap
+        env:
+          GO111MODULE: on
+      - uses: actions/checkout@v2
+      - run: go generate ./...
+      - name: Check for changes
+        run: |
+          git diff --name-only --exit-code || ( echo "Rerun go generate ./... locally and resubmit" && false )
 
   excludereplace:
     name: Exclude Replace in go.mod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,19 +101,10 @@ jobs:
     name: Check generated files
     runs-on: ubuntu-latest
     steps:
-      - uses: arduino/setup-protoc@master
-        with:
-          version: '3.8.0'
+      - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
           go-version: 1.15
-      - name: Instal go generate tools
-        run: |
-          go get -u github.com/golang/protobuf/protoc-gen-go@v1.3.3
-          go get github.com/searKing/golang/tools/cmd/go-syncmap
-        env:
-          GO111MODULE: on
-      - uses: actions/checkout@v2
       - run: go generate ./...
       - name: Check for changes
         run: |


### PR DESCRIPTION
1. `sdk-vppagent` should be replaced with `sdk-vpp` in dependencies check.
2. `go generate` check should check not only `*.gen.go` files.

Refers to #61.