### PR TITLE
fix: Some of networkservicemesh cmd-* repos not getting update from cmd-template

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,33 +149,3 @@ jobs:
             pr-${{ steps.findPr.outputs.pr }}
             commit-${{ github.sha }}
             latest
-
-  pushImage:
-    name: Push docker image
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_USER: ${{ secrets.DOCKER_LOGIN }}
-      ORG: networkservicemeshci
-      CGO_ENABLED: 0
-      NAME: ${{ github.event.repository.name }}
-    needs:
-      - build
-      - docker
-    if: github.actor == 'nsmbot' && github.base_ref == 'master' && github.event_name == 'pull_request' && github.repository != 'networkservicemesh/cmd-template'
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
-        with:
-          go-version: 1.16
-      - name: Build ${NAME}:${GITHUB_SHA::8} image
-        run: docker build . -t "${ORG}/${NAME}:${GITHUB_SHA::8}" --target runtime
-      - name: Build ${NAME}:latest image
-        run: docker build . -t "${ORG}/${NAME}" --target runtime
-      - name: Push ${NAME} images
-        run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-          docker push "${ORG}/${NAME}:${GITHUB_SHA::8}"
-          docker image rm "${ORG}/${NAME}:${GITHUB_SHA::8}"
-          docker push "${ORG}/${NAME}"
-          docker image rm "${ORG}/${NAME}"

--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Run `get-organization-repositories`
         id: organization-repositories
-        uses: denis-tingajkin/get-organization-repositories@v1
+        uses: denis-tingajkin/get-organization-repositories@v1.0.1
         with:
           github-organization: 'networkservicemesh'
           regex: 'cmd-.*'


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Description

Some of repos not getting updates from cmd-template. For example:
https://github.com/networkservicemesh/cmd-nsc-init

Note: there is not any sync update from cmd-template.

I found that it is a problem of `denis-tingajkin/get-organization-repositories@v1`. 
It had the limitation of getting repositories relating to the organization.

This problem is fixed in `v1.0.1`

https://github.com/denis-tingaikin/get-organization-repositories/compare/v1...v1.0.1