### PR TITLE
Exclude .golangci config from sync with cmd-template

### DIFF
--- a/.github/workflows/update-cmd-repositories.yaml
+++ b/.github/workflows/update-cmd-repositories.yaml
@@ -47,3 +47,4 @@ jobs:
           allow-files-pattern: (.*\.yaml|.*\.yml|.*\.txt|.*\.md|.*\.conf)
           exclude-files: |
             .github/workflows/update-cmd-repositories.yaml
+            .golangci.yml


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>