### PR TITLE
fix: release workflow checkouts 'main' branch instead of 'release/v.*' branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+        with:
+          ref: refs/heads/${{github.event.workflow_run.head_branch}}
 
       - name: Check go.mod deps
         run: |
@@ -76,6 +78,8 @@ jobs:
 
       - name: "Checkout"
         uses: actions/checkout@v2
+        with:
+          ref: refs/heads/${{github.event.workflow_run.head_branch}}
 
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


Fixes a few issues that we added in https://github.com/networkservicemesh/cmd-template/pull/88