### PR TITLE
Replace github.ref with github.event_name

### DIFF
--- a/.github/workflows/docker-push-ghcr.yml
+++ b/.github/workflows/docker-push-ghcr.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -19,7 +19,7 @@ jobs:
       ORG: networkservicemeshci
       CGO_ENABLED: 0
       NAME: ${{ github.event.repository.name }}
-    if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.ref == 'refs/heads/main') }}
+    if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1

--- a/.github/workflows/update-deployments.yaml
+++ b/.github/workflows/update-deployments.yaml
@@ -13,7 +13,7 @@ jobs:
   update-deployments-k8s:
     name: Update deployments-k8s
     runs-on: ubuntu-latest
-    if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.ref == 'refs/heads/main') }}
+    if: ${{ github.repository != 'networkservicemesh/cmd-template' && (github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push') }}
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2


### PR DESCRIPTION
Closes: https://github.com/networkservicemesh/cmd-template/issues/98
Replace `github.ref` with `github.event_name` to determine push to the main branch.

`push`, `docker-push-ghcr` and `Update deployments-k8s` reposiotry workflows are triggered by `automerge` **_or_** push to main branch. 
But since these are different workflows, `github.ref` always equals to `refs/heads/main`

For information: `github.event.workflow_run.head_branch` also doesn't work, because:
`ci` -----> `automerge` (head_branch == **_your_branch_**) -----> `docker-push-ghcr` (head_branch == _**main**_)


Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>