### PR TITLE
Update go to 1.18

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Update version manually
         run: |
           branch=${{ needs.automerge.outputs.pr_branch_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Build
         run: go build -race ./...
 
@@ -55,11 +55,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.35.0
+          version: v1.45.2
 
   excludeFmtErrorf:
     name: exclude fmt.Errorf
@@ -80,13 +80,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Restrict dependencies on github.com/networkservicemesh/*
         env:
-          ALLOWED_REPOSITORIES: "api, sdk, sdk-k8s, sdk-kernel, sdk-sriov, sdk-vpp"
+          ALLOWED_REPOSITORIES: "api sdk sdk-k8s sdk-kernel sdk-sriov sdk-vpp"
+
         run: |
-          for i in $(grep github.com/networkservicemesh/ go.mod | grep -v '^module' | sed 's;.*\(github.com\/networkservicemesh\/[^ ]*\).*;\1;g');do
-            if ! [ "$(echo ${ALLOWED_REPOSITORIES} | grep ${i#github.com/networkservicemesh/})" ]; then
-              echo Dependency on "${i}" is forbidden
-              exit 1
-            fi;
+          for i in $(grep -v '// indirect' go.mod | gsed -n 's:^\tgithub.com/networkservicemesh/\([^ ]\+\) .*:\1:p'); do
+            ! [[ " $ALLOWED_REPOSITORIES " =~ " $i " ]] || continue
+            echo Dependency on "${i}" is forbidden
+            exit 1
           done
 
   checkgomod:
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - run: go mod tidy
       - name: Check for changes
         run: |
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - run: go generate ./...
       - name: Check for changes
         run: |
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Build container
         run: docker build .
       - name: Run tests

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Build ${NAME}:${GITHUB_SHA::8} image
         run: docker build . -t "${ORG}/${NAME}:${GITHUB_SHA::8}" --target runtime
       - name: Build ${NAME}:latest image

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,8 +10,9 @@ linters-settings:
     values:
       regexp:
         company: .*
-        copyright-holder: Copyright \(c\) ({{year-range}}) {{company}}\n\n
-        copyright-holders: ({{copyright-holder}})+
+        copyright-holder-curr: Copyright \(c\) ({{year-range}}) {{company}}\n\n
+        copyright-holder: Copyright \(c\) .*\n\n
+        copyright-holders: ({{copyright-holder}})*({{copyright-holder-curr}})+({{copyright-holder}})*
   errcheck:
     check-type-assertions: false
     check-blank: false
@@ -24,7 +25,7 @@ linters-settings:
           - (github.com/sirupsen/logrus.FieldLogger).Warnf
           - (github.com/sirupsen/logrus.FieldLogger).Errorf
           - (github.com/sirupsen/logrus.FieldLogger).Fatalf
-  golint:
+  revive:
     min-confidence: 0.8
   goimports:
     local-prefixes: github.com/networkservicemesh
@@ -143,7 +144,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
@@ -152,7 +153,7 @@ linters:
     # - lll
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM golang:1.16-buster as go
+FROM golang:1.18-bullseye as go
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOBIN=/bin
-RUN go get github.com/go-delve/delve/cmd/dlv@v1.6.0
-RUN go get github.com/edwarnicke/dl
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.6.0
+RUN go install github.com/edwarnicke/dl@latest
 RUN dl \
     https://github.com/spiffe/spire/releases/download/v1.2.2/spire-1.2.2-linux-x86_64-glibc.tar.gz | \
     tar -xzvf - -C /bin --strip=2 spire-1.2.2/bin/spire-server spire-1.2.2/bin/spire-agent
 
 FROM go as build
 WORKDIR /build
+COPY go.mod go.sum ./
+COPY ./internal/imports internal/imports
+RUN go build ./internal/imports
 COPY . .
 RUN go build -o /bin/app .
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/networkservicemesh/cmd-template
 
-go 1.16
+go 1.18


### PR DESCRIPTION
https://github.com/networkservicemesh/sdk/issues/1264

* Update Dockerfiles to use `go:1.18-bullseye` instead of `go:1.16-buster`.
* In GitHub workflow yamls, update go to 1.18 and golangci-lint to 1.45.2.
* Update `go.mod` files to use `go 1.18`.
* Replace deprecated linters: `golint` -> `revive`, `scopelint` -> exportloopref`.
* Fix `goheader` linting rule configuration.
* Fix linter issues introduced by the new golangci-lint version.