### PR TITLE
Upgraded base go image to golang:1.23.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.12 as go
+FROM golang:1.23.1 as go
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOBIN=/bin


### PR DESCRIPTION
Fixing critical vulnerabilities for cmd repositories, that comes from used go version

Issue: https://github.com/networkservicemesh/deployments-k8s/issues/12283